### PR TITLE
release: bump to 0.14.0-0.3.0

### DIFF
--- a/CHANGELOG-LINK.md
+++ b/CHANGELOG-LINK.md
@@ -4,7 +4,7 @@ This is CHANGELOG after this repository was forked from CosmWasm/wasmvm.
 ## 0.14.0-0.3.0
 ## Changes
 - Update upstream Cosmwasm/wasmvm version to 0.14.0-beta1 (#8)
-- Update the depended line/cosdmwasm version to 0.14.0-0.3.0 (#8)
+- Update the depended line/cosmwasm version to 0.14.0-0.3.0 (#8)
 - Adjust semantic PR validation rule (#9)
 
 ## 0.12.0-0.1.0


### PR DESCRIPTION
We decided to depend on the line/wasmvm version to the line/cosmwasm version.
So the -0.2.0 version is skipped.

The cargo version was already wrote during the merge process(mistake).
