### PR TITLE
build: change cargo use to tag from the version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
 [[package]]
 name = "cosmwasm-crypto"
 version = "0.14.0-0.3.0"
-source = "git+https://github.com/line/cosmwasm?branch=main#e7051e5c52f29a534bf5b222acd35515258d51b9"
+source = "git+https://github.com/line/cosmwasm?tag=v0.14.0-0.3.0#e7051e5c52f29a534bf5b222acd35515258d51b9"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -181,7 +181,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-derive"
 version = "0.14.0-0.3.0"
-source = "git+https://github.com/line/cosmwasm?branch=main#e7051e5c52f29a534bf5b222acd35515258d51b9"
+source = "git+https://github.com/line/cosmwasm?tag=v0.14.0-0.3.0#e7051e5c52f29a534bf5b222acd35515258d51b9"
 dependencies = [
  "syn",
 ]
@@ -189,7 +189,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-std"
 version = "0.14.0-0.3.0"
-source = "git+https://github.com/line/cosmwasm?branch=main#e7051e5c52f29a534bf5b222acd35515258d51b9"
+source = "git+https://github.com/line/cosmwasm?tag=v0.14.0-0.3.0#e7051e5c52f29a534bf5b222acd35515258d51b9"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -203,7 +203,7 @@ dependencies = [
 [[package]]
 name = "cosmwasm-vm"
 version = "0.14.0-0.3.0"
-source = "git+https://github.com/line/cosmwasm?branch=main#e7051e5c52f29a534bf5b222acd35515258d51b9"
+source = "git+https://github.com/line/cosmwasm?tag=v0.14.0-0.3.0#e7051e5c52f29a534bf5b222acd35515258d51b9"
 dependencies = [
  "clru",
  "cosmwasm-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ default = []
 backtraces = []
 
 [dependencies]
-cosmwasm-std = { git = "https://github.com/line/cosmwasm", version = "0.14.0-0.3.0", branch = "main", features = ["iterator","staking","stargate"] }
-cosmwasm-vm = {  git = "https://github.com/line/cosmwasm", version = "0.14.0-0.3.0", branch = "main", features = ["iterator","staking","stargate"] }
+cosmwasm-std = { git = "https://github.com/line/cosmwasm", tag = "v0.14.0-0.3.0", features = ["iterator","staking","stargate"] }
+cosmwasm-vm = {  git = "https://github.com/line/cosmwasm", tag = "v0.14.0-0.3.0", features = ["iterator","staking","stargate"] }
 errno = "0.2"
 serde_json = "1.0"
 thiserror = "1.0"


### PR DESCRIPTION
The version and branch specifications are used incorrectly.
Change to tag usage.