### PR TITLE
ci: add github actions config

### DIFF
--- a/.github/workflows/builds_and_tests.yml
+++ b/.github/workflows/builds_and_tests.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Builds and Tests
 
 on: [pull_request]
 


### PR DESCRIPTION
closes https://github.com/line/cosmwasm/issues/90

- Jobs to be checked in the pull request
  - sanity
  - build_shared_library
  - test
- Jobs related to release
  - build_static_lib
  - test_alpine_build
  - deploy_to_git

Therefore, I think that release related jobs should be moved to github actions when the release is automated.
In this PR, only jobs related to PR are set to github actions.