### PR TITLE
fix: fix a test for rustc 1.68 or later

### DIFF
--- a/libwasmvm/src/cache.rs
+++ b/libwasmvm/src/cache.rs
@@ -372,7 +372,9 @@ mod tests {
         assert!(cache_ptr.is_null());
         assert!(error_msg.is_some());
         let msg = String::from_utf8(error_msg.consume().unwrap()).unwrap();
-        assert_eq!(msg, "Error calling the VM: Cache error: Error creating directory broken\u{0}dir/state: data provided contains a nul byte");
+        assert!(msg.starts_with(
+            "Error calling the VM: Cache error: Error creating directory broken\u{0}dir/state"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

Without this PR, libwasmvm's test `init_cache_writes_error` fails in rustc v1.68 (stable now) or later. (#107)
This PR fixes the test for both of rustc before/after v1.68.

Closes #107 

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/line/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
