### PR TITLE
feat: Add static build for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,14 +66,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build docker image
-        run: cd builders && make docker-image-alpine
+        run: cd builders && make docker-image-alpine && make docker-image-cross
       - name: Build & Test static library
         run: make release-build-alpine
+      - name: Build static library for MacOS
+        run: make release-build-macos-static
       - name: Collect artifacts
         run: |
           mkdir artifacts
           cp ./internal/api/libwasmvm_muslc.a ./artifacts/libwasmvm_muslc.x86_64.a
           cp ./internal/api/libwasmvm_muslc.aarch64.a ./artifacts/libwasmvm_muslc.aarch64.a
+          cp ./internal/api/libwasmvmstatic_darwin.a ./artifacts/libwasmvmstatic_darwin.a
       - name: Create checksums
         working-directory: ./artifacts
         run: sha256sum * > checksums.txt && cat checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/Finschia/wasmvm/compare/v1.1.1-0.11.2...HEAD)
 
 ### Features
+* feat: Add static build for macos ([#115](https://github.com/Finschia/wasmvm/pull/115))
 
 ### Fixes
 

--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ release-build:
 	make release-build-linux
 	make release-build-macos
 	make release-build-windows
+	make release-build-macos-static
 
 test-alpine: release-build-alpine
 # try running go tests using this lib with muslc

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,17 @@ release-build-macos:
 	cp libwasmvm/artifacts/libwasmvm.dylib internal/api
 	make update-bindings
 
+# Creates a release build in a containerized build environment of the static library for macOS (.a)
+release-build-macos-static:
+	rm -rf libwasmvm/target/x86_64-apple-darwin/release
+	rm -rf libwasmvm/target/aarch64-apple-darwin/release
+	docker run --rm -u $(USER_ID):$(USER_GROUP) \
+		-v $(shell pwd)/libwasmvm:/code \
+		-v $(shell pwd)/builders/guest/build_macos_static.sh:/usr/local/bin/build_macos_static.sh \
+		$(BUILDERS_PREFIX)-cross build_macos_static.sh
+	cp libwasmvm/artifacts/libwasmvmstatic_darwin.a internal/api/libwasmvmstatic_darwin.a
+	make update-bindings
+
 # Creates a release build in a containerized build environment of the shared library for Windows (.dll)
 release-build-windows:
 	rm -rf libwasmvm/target/release

--- a/builders/guest/build_macos_static.sh
+++ b/builders/guest/build_macos_static.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -o errexit -o nounset -o pipefail
+
+# ref: https://wapl.es/rust/2019/02/17/rust-cross-compile-linux-to-macos.html
+export PATH="/opt/osxcross/target/bin:$PATH"
+export LIBZ_SYS_STATIC=1
+
+# See https://github.com/CosmWasm/wasmvm/issues/222#issuecomment-880616953 for two approaches to
+# enable stripping through cargo (if that is desired).
+
+echo "Starting aarch64-apple-darwin build"
+export CC=aarch64-apple-darwin20.4-clang
+export CXX=aarch64-apple-darwin20.4-clang++
+cargo build --release --target aarch64-apple-darwin --example wasmvmstatic
+
+echo "Starting x86_64-apple-darwin build"
+export CC=o64-clang
+export CXX=o64-clang++
+cargo build --release --target x86_64-apple-darwin --example wasmvmstatic
+
+# Create a universal library with both archs
+lipo -output artifacts/libwasmvmstatic_darwin.a -create \
+  target/x86_64-apple-darwin/release/examples/libwasmvmstatic.a \
+  target/aarch64-apple-darwin/release/examples/libwasmvmstatic.a

--- a/internal/api/link_mac.go
+++ b/internal/api/link_mac.go
@@ -1,5 +1,4 @@
-//go:build darwin && !sys_wasmvm
-// +build darwin,!sys_wasmvm
+//go:build darwin && !static_wasm && !sys_wasmvm
 
 package api
 

--- a/internal/api/link_mac_static.go
+++ b/internal/api/link_mac_static.go
@@ -1,0 +1,6 @@
+//go:build darwin && static_wasm && !sys_wasmvm
+
+package api
+
+// #cgo LDFLAGS: -L${SRCDIR} -lwasmvmstatic_darwin
+import "C"

--- a/libwasmvm/Cargo.toml
+++ b/libwasmvm/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 exclude = [".circleci/*", ".gitignore"]
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 # the example is to allow us to compile a muslc static lib with the same codebase as we compile the
 # normal dynamic libs (best workaround I could find to override crate-type on the command line)
@@ -20,9 +20,10 @@ name = "muslc"
 path = "src/lib.rs"
 crate-type = ["staticlib"]
 
-# # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-# [badges]
-# maintenance = { status = "actively-developed" }
+[[example]]
+name = "wasmvmstatic"
+path = "src/examples/wasmvmstatic.rs"
+crate-type = ["staticlib"]
 
 [features]
 default = []

--- a/libwasmvm/src/examples/wasmvmstatic.rs
+++ b/libwasmvm/src/examples/wasmvmstatic.rs
@@ -1,0 +1,1 @@
+pub use wasmvm::*;


### PR DESCRIPTION
# Description

Add static build for macos.
Add static library for macos in release github action as release assets. The asset file of static library is `libwasmvmstatic_darwin.a` and it's a little big size. So I didn't add as github file in the `internal/api` directory.

This PR is cherry pick PR of [cosmwasm/wasmvm v1.2.1](https://github.com/CosmWasm/wasmvm/releases/tag/v1.2.1)


## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [x] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
