### PR TITLE
ci: change test internal libwasmvm binary triggered only build PR

### DIFF
--- a/.github/workflows/builds_and_tests.yml
+++ b/.github/workflows/builds_and_tests.yml
@@ -108,6 +108,7 @@ jobs:
         run: ./devtools/check_shellscript_lint.sh
 
   test_internal_shared_lib:
+    if: ${{ github.event.pusher.name == 'finschia-auto-pr[bot]' }}
     runs-on: ubuntu-latest
     env:
       GORACE: "halt_on_error=1"

--- a/.github/workflows/builds_and_tests.yml
+++ b/.github/workflows/builds_and_tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Run shellcheck
         run: ./devtools/check_shellscript_lint.sh
 
-  test_internal_shared_lib:
+  test_internal_shared_lib_on_auto_build_pr:
     if: ${{ github.event.pusher.name == 'finschia-auto-pr[bot]' }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/deploy_to_git.yml
+++ b/.github/workflows/deploy_to_git.yml
@@ -127,7 +127,7 @@ jobs:
         run: |
           git config user.name  "finschia-auto-pr[bot]"
           git config user.email "141415241+finschia-auto-pr[bot]@users.noreply.github.com"
-          git commit -m "chore: auto generate shared library"
+          git commit -m "build: auto generate shared library"
       - name: Create pull request
         if: steps.cd.outputs.need_update=='true'
         id: cpr
@@ -138,7 +138,7 @@ jobs:
           branch: auto_shared_library_${{ steps.prn.outputs.latest_pr_number }}
           base: ${{ github.ref_name }}
           delete-branch: true
-          title: 'chore: (auto)update shared library'
+          title: 'build: (auto)update shared library'
           body: |
             # Description
             Update shared library

--- a/.github/workflows/deploy_to_git.yml
+++ b/.github/workflows/deploy_to_git.yml
@@ -23,7 +23,7 @@ jobs:
       # and .dll builds are not deterministic.
       # Deactivating this step to avoid polluting the git hostory.
         os: [linux, macos]
-        include: 
+        include:
           - os: linux
             dockerfile_name: centos7
             shared_library_extension: so
@@ -115,7 +115,7 @@ jobs:
           gh pr list --state open --json author,number | jq -r '.[] | select(.author.login == "app/finschia-auto-pr") | .number' | while read -r pr_number; do
             gh pr close -d -c "This pr is out of date." $pr_number
           done
-        env: 
+        env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Get latest PR
         id: prn
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build_shared_library, deploy_to_git]
     if: |
-      always() && 
+      always() &&
       ( needs.build_shared_library.result=='success' || needs.build_shared_library.result=='skipped' ) &&
       ( github.event.pusher.name == 'finschia-auto-pr[bot]' || needs.deploy_to_git.outputs.updated=='false' )
     outputs:
@@ -195,7 +195,7 @@ jobs:
     name: Push Tag
     needs: [build_shared_library, get-version]
     if: |
-      always() && 
+      always() &&
       ( needs.build_shared_library.result=='success' || needs.build_shared_library.result=='skipped' ) &&
       ( needs.get-version.outputs.package-version != needs.get-version.outputs.latest-tag )
     runs-on: ubuntu-latest
@@ -210,7 +210,7 @@ jobs:
     name: Update releases
     needs: [build_shared_library, push-tag]
     if: |
-      always() && 
+      always() &&
       ( needs.build_shared_library.result=='success' || needs.build_shared_library.result=='skipped' ) &&
       ( needs.push-tag.result=='success' )
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR changes the trigger of the test of internal libwasmvm binaries.
This is always triggered before this PR, and this PR changes it triggered only PR by the libwasmvm build bot.

# Description

wasmvm has 2 tests for PR for the main branch, before this PR.

- Building libwasmvm binaries from the source and doing tests with it
- Doing tests with libwasmvm included in internal/api directory

An error is caused in CI when internal/api's libwasmvm is old, though we have a CI building libwasmvm binaries after the main branch is updated.
As a result, if PR publishers think that they leave building libwasmvm on CI after the merge, internal libwasmvm's test fails. (now we have this issue on https://github.com/Finschia/wasmvm/pull/142)

To solve this, we change the trigger of the test of internal/api's libwasmvm binaries.

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I followed the [contributing guidelines](https://github.com/Finschia/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly. (not needed)
- [ ] I have added tests to cover my changes. (not needed)
- [x] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
