### PR TITLE
ci: fix update-release workflow dependency

### DIFF
--- a/.github/workflows/deploy_to_git.yml
+++ b/.github/workflows/deploy_to_git.yml
@@ -208,7 +208,7 @@ jobs:
 
   update-releases:
     name: Update releases
-    needs: [build_shared_library, push-tag]
+    needs: [build_shared_library, get-version, push-tag]
     if: |
       always() &&
       ( needs.build_shared_library.result=='success' || needs.build_shared_library.result=='skipped' ) &&


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. -->
<!-- Please also include relevant motivation and context. -->
<!-- List any dependencies that are required for this change. -->
This PR fix the update-release workflow dependency, since currently cannot read the property value of `package-version`
https://github.com/Finschia/wasmvm/actions/runs/7971589615/job/21761801180#step:9:11

## Types of changes

<!-- What types of changes does your code introduce? -->
<!-- Put an `x` in all the boxes that apply. -->

- [ ] Bug fix (changes which fixes an issue)
- [ ] New feature (changes which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] ETC (build, ci, docs, perf, refactor, style, test)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I followed the [contributing guidelines](https://github.com/Finschia/wasmvm/blob/main/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] The PR title and commits are followed [conventional commit form](https://www.conventionalcommits.org/en/v1.0.0).
